### PR TITLE
restrict copyright to show only the year, not full time

### DIFF
--- a/indigo/_includes/footer.html
+++ b/indigo/_includes/footer.html
@@ -36,7 +36,7 @@
       <li class="footer__item text-muted small">University College London,&nbsp;Gower Street,&nbsp;London,&nbsp;WC1E 6BT&nbsp;Tel:&nbsp;+44&nbsp;(0)&nbsp;20 7679 2000</li>
     </ul>
     <ul class="list-inline footer__list list-unstyled list-inline--divided">
-      <li class="text-muted small">Copyright © {{ site.time }} UCL</li>
+      <li class="text-muted small">Copyright © {{ site.time | date: '%Y' }} UCL</li>
       <li class="text-muted small"><a href="#">Disclaimer</a>
       </li>
       <li class="text-muted small"><a href="#">Freedom of Information</a>


### PR DESCRIPTION
It works as shown in [GSOC page](http://github-pages.ucl.ac.uk/GSOC/) as implemented in UCL/GSOC@efb2fff9197565b3ae3276194fbdeb4e7fb6c609