### PR TITLE
Check for existence of `ipython.css`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+_site
+.jekyll-cache
+vendor

--- a/_includes/base.html
+++ b/_includes/base.html
@@ -29,8 +29,12 @@
   <!--link href="//cdn.ucl.ac.uk/skins/font-awesome/css/font-awesome.min.css" rel="stylesheet"-->
   <link href="{{site.baseurl}}/assets/css/screen.min.css" media="screen, projection" rel="stylesheet" type="text/css" />
   <link href="{{site.baseurl}}/assets/css/jekyll-styles.css" rel="stylesheet" type="text/css">
-  <link href="{{site.baseurl}}/site-styles/local_styles.css" rel="stylesheet" type="text/css">
+  {% assign ipythonstylepath = "/site-styles/ipython.css" %}
+  {% assign file = site.static_files | where: "path", ipythonstylepath | first %}
+  {% if file %}
   <link href="{{site.baseurl}}/site-styles/ipython.css" rel="stylesheet" type="text/css">
+  {% endif %}
+  <link href="{{site.baseurl}}/site-styles/local_styles.css" rel="stylesheet" type="text/css">
   <link rel="stylesheet" media="screen, projection" href="//cdn.ucl.ac.uk/skins/UCLDrupalIndigoSkin/default-theme/css/brightblue.min.css?sspcng">
 
   <link rel="shortcut icon" href="{{site.baseurl}}/assets/images/favicon.ico" />


### PR DESCRIPTION
- Check for the existence of ipython style file before including. 
- Also add a .gitignore.

Fixes
- #23 

Note this is a hack. A better way would be to remove the file (and maybe the whole site-styles dir) and downstream users should extend the `head` with their own stylesheets.

- https://jekyllrb.com/docs/themes/#overriding-theme-defaults