### PR TITLE
Avoid redirects, use directly `https://www.ucl.ac.uk`

### DIFF
--- a/_includes/base.html
+++ b/_includes/base.html
@@ -14,10 +14,10 @@
     <meta name="twitter:title" content="UCL - London's Global University">
     <meta name="twitter:description" content="UCL (University College London) is London's leading multidisciplinary university, with 8,000 staff and 25,000 students.">
     <meta name="twitter:creator" content="@UCLWAMS">
-    <meta name="twitter:image:src" content="https://ucl.ac.uk/visual-identity/logos/standalone.png">
-    <meta property="og:image" content="https://ucl.ac.uk/visual-identity/logos/standalone.png" />
+    <meta name="twitter:image:src" content="https://www.ucl.ac.uk/visual-identity/logos/standalone.png">
+    <meta property="og:image" content="https://www.ucl.ac.uk/visual-identity/logos/standalone.png" />
     <meta property="og:title" content="UCL - London's Global University" />
-    <meta property="og:url" content="https://ucl.ac.uk" />
+    <meta property="og:url" content="https://www.ucl.ac.uk" />
     <meta property="og:site_name" content="UCL" />
     <meta property="og:description" content="UCL (University College London) is London's leading multidisciplinary university, with 8,000 staff and 25,000 students." />
     <meta property="og:type" content="website" />

--- a/_includes/crumbs.html
+++ b/_includes/crumbs.html
@@ -1,4 +1,4 @@
-<li class="breadcrumb__item"><a href="https://ucl.ac.uk/">UCL Home</a></li>
+<li class="breadcrumb__item"><a href="https://www.ucl.ac.uk/">UCL Home</a></li>
 {% if site.crumbs %}
   {% for crumb in site.crumbs %}
     <li class="breadcrumb__item"><a href="{{crumb.link}}">{{crumb.text}}</a></li>

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1564,7 +1564,7 @@ figure + figure, figure + p {
     width: 100%; } }
 /* 
 * Base name: Grid
-* Note: Applying Indigo grid to custom breakpoints. See - https://ucl.ac.uk/indigo/grid.php
+* Note: Applying Indigo grid to custom breakpoints. See - https://www.ucl.ac.uk/indigo/grid.php
 -------------------------------------------------------------- */
 @media (max-width: 619px) {
   .col {

--- a/assets/js/app/general.js
+++ b/assets/js/app/general.js
@@ -164,7 +164,7 @@ define(["jquery","allsite"],function($,gen){
 		}
 		if(isCompatabilityMode || debug){
 			var messageStr = "<p>This website will not display correctly in compatibilty mode.";
-			messageStr += " For more information please see <a href='https://ucl.ac.uk/indigo/design-foundation/indigo-constraints'>Indigo constraints</a></p>";
+			messageStr += " For more information please see <a href='https://www.ucl.ac.uk/indigo/design-foundation/indigo-constraints'>Indigo constraints</a></p>";
 			
 			$('body').prepend("<div class='announcement-bar'>" + messageStr + "</a><a href='#' class='announcement-bar--close'>x</span>");
 

--- a/assets/sass/base/_grid.scss
+++ b/assets/sass/base/_grid.scss
@@ -1,6 +1,6 @@
 /* 
 * Base name: Grid
-* Note: Applying Indigo grid to custom breakpoints. See - https://ucl.ac.uk/indigo/grid.php
+* Note: Applying Indigo grid to custom breakpoints. See - https://www.ucl.ac.uk/indigo/grid.php
 -------------------------------------------------------------- */
 
 .col {


### PR DESCRIPTION
Ref: https://github.com/UCL-ARC/indigo-jekyll/pull/27#discussion_r2589450316.  When looking at linkchecker result over at https://github.com/UCL/open-source there's lots of noise due to these redirects, we can resolve the redirect and avoid any noise.